### PR TITLE
[codex] Fix match result reconciliation

### DIFF
--- a/src/main/kotlin/FootballBot.kt
+++ b/src/main/kotlin/FootballBot.kt
@@ -32,6 +32,7 @@ import service.DatabaseService
 import service.HttpAPIFootballService
 import service.StrategyService
 import service.initDatabase
+import service.isUnavailableFixtureStatus
 import service.HttpLocalModelService
 import service.ChatGPTService
 import service.StarsPaymentService
@@ -262,6 +263,19 @@ class FootballBot(private val token: String) : TelegramLongPollingBot(), Telegra
         markup.keyboard = listOf(listOf(button))
         sendMessage(channelId, text, replyMarkup = markup)
         DatabaseService.polls.markPollClosed(match.fixtureId)
+    }
+
+    fun finalizeMatchPollIfNeeded(match: MatchInfo) {
+        if (match.actualOutcome == null) return
+
+        val poll = DatabaseService.polls.getPollByFixtureId(match.fixtureId) ?: return
+        if (poll.closed) return
+
+        try {
+            finalizePoll(match, poll)
+        } catch (e: Exception) {
+            logger.error("Failed to finalize poll for fixture ${match.fixtureId}", e)
+        }
     }
 
     private fun isPremiumMatch(match: MatchInfo): Boolean {
@@ -1902,28 +1916,14 @@ Available actions:
         val upcomingMatches = DatabaseService.matches.getUpcomingMatchesWithMessageId()
         val updatedByMessageId = mutableMapOf<String, MutableList<MatchInfo>>()
         val updatedByStrategyId = mutableMapOf<String, MutableList<MatchInfo>>()
-        val removedMainMessages = mutableSetOf<Pair<String, String>>()
-        val removedStrategyMessages = mutableSetOf<Pair<String, String>>()
-
-        fun trackRemovedMessage(match: MatchInfo) {
-            match.telegramMessageId?.let { id ->
-                removedMainMessages.add(match.matchType to id)
-            }
-            match.strategyTelegramMessageId?.let { id ->
-                removedStrategyMessages.add(match.matchType to id)
-            }
-        }
-
-        fun handleUnavailableFixture(match: MatchInfo): Boolean {
-            DatabaseService.matches.deleteMatchByFixtureId(match.fixtureId, match.matchType)
-            trackRemovedMessage(match)
-            return true
-        }
 
         for (match in ongoingMatches) {
             val liveResult = footballService.getLiveMatchInfoWithStatus(match.fixtureId)
-            if (liveResult?.statusShort == "PST" || liveResult?.statusShort == "CANC") {
-                handleUnavailableFixture(match)
+            if (isUnavailableFixtureStatus(liveResult?.statusShort)) {
+                logger.info(
+                    "Fixture ${match.fixtureId} reported ${liveResult?.statusShort}; " +
+                            "deferring removal to past-match reconciliation"
+                )
                 delay(1000)
                 continue
             }
@@ -1932,10 +1932,7 @@ Available actions:
             if (updatedMatchInfo != null) {
                 DatabaseService.matches.updateMatchResult(updatedMatchInfo)
 
-                val poll = DatabaseService.polls.getPollByFixtureId(updatedMatchInfo.fixtureId)
-                if (poll != null && !poll.closed && updatedMatchInfo.actualOutcome != null) {
-                    finalizePoll(updatedMatchInfo, poll)
-                }
+                finalizeMatchPollIfNeeded(updatedMatchInfo)
 
                 updatedMatchInfo.telegramMessageId?.let { id ->
                     updatedByMessageId.getOrPut(id) { mutableListOf() }.add(updatedMatchInfo)
@@ -1979,72 +1976,6 @@ Available actions:
             val messageText = formatPremiumMatchesBatchForUpdate(matches)
             updateMessage(strategyChannelId, messageId, messageText, null)
             delay(10000)
-        }
-
-        for ((league, msgId) in removedMainMessages) {
-            val remaining = DatabaseService.matches.getMatchesByLeagueAndTelegramMessageId(league, msgId)
-            if (remaining.isEmpty()) {
-                deleteMatchMessages(
-                    MatchInfo(
-                        fixtureId = "",
-                        datetime = "",
-                        matchType = league,
-                        teams = "",
-                        predictedOutcome = null,
-                        actualOutcome = null,
-                        predictedScore = null,
-                        actualScore = null,
-                        odds = null,
-                        bookmakerName = null,
-                        homeWinOdds = null,
-                        drawOdds = null,
-                        awayWinOdds = null,
-                        telegramMessageId = msgId,
-                        strategyTelegramMessageId = null,
-                        elapsed = null,
-                        modelHomeWinProb = null,
-                        modelDrawProb = null,
-                        modelAwayWinProb = null,
-                        modelExpectedHomeGoals = null,
-                        modelExpectedAwayGoals = null
-                    )
-                )
-            } else {
-                updateMatchMessages(remaining.first())
-            }
-        }
-
-        for ((league, msgId) in removedStrategyMessages) {
-            val remaining = DatabaseService.matches.getMatchesByLeagueAndStrategyMessageId(league, msgId)
-            if (remaining.isEmpty()) {
-                deleteMatchMessages(
-                    MatchInfo(
-                        fixtureId = "",
-                        datetime = "",
-                        matchType = league,
-                        teams = "",
-                        predictedOutcome = null,
-                        actualOutcome = null,
-                        predictedScore = null,
-                        actualScore = null,
-                        odds = null,
-                        bookmakerName = null,
-                        homeWinOdds = null,
-                        drawOdds = null,
-                        awayWinOdds = null,
-                        telegramMessageId = null,
-                        strategyTelegramMessageId = msgId,
-                        elapsed = null,
-                        modelHomeWinProb = null,
-                        modelDrawProb = null,
-                        modelAwayWinProb = null,
-                        modelExpectedHomeGoals = null,
-                        modelExpectedAwayGoals = null
-                    )
-                )
-            } else {
-                updateMatchMessages(remaining.first())
-            }
         }
     }
 

--- a/src/main/kotlin/repository/FUNCTIONS.md
+++ b/src/main/kotlin/repository/FUNCTIONS.md
@@ -5,7 +5,7 @@
 ## MatchRepository.kt
 - League table management: `appendRows()`, `updateMatchResult()`, and helpers keep per-league tables in sync; `createLeagueTableIfNeeded`/`addMissingColumnsForLeague` are invoked upstream when adding rows.
 - Prediction fields: `updateMatchPredictions()`, `updateMatchOdds()`, `updateMatchMessageId()`, `updateMatchStrategyMessageId()`, `updateMatchDatetime()`, and `updateMatchTeams()` keep model outputs and Telegram ids current.
-- Queries: `getUpcomingMatches*()`, `getOngoingMatches()`, `getMatchesFromLastDaysWithoutResult()`, `getLastMatches*()`, `getMatchesBy*()` fetch slices for messaging, cleanup, and stats.
+- Queries: `getUpcomingMatches*()`, `getOngoingMatches()`, `getMatchesAroundNowWithoutResult()`, `getLastMatches*()`, `getMatchesBy*()` fetch slices for messaging, reconciliation, and stats.
 - Statistics: `updateLeaguePredictability()`, `getLeaguePredictabilityData()`, `getStatisticsForPeriod()`, `getDetailedStatisticsForPeriod()`, `getTopPremiumRoiMatchesForPeriod()` aggregate ROI/accuracy metrics and team match counts.
 - Utilities: `matchExists()`, `deleteMatchByFixtureId()`, `getMatchInfoByFixtureId()`, and helpers that normalize league naming and team counts.
 
@@ -16,7 +16,7 @@
 - Rate limiting: `incrementUsage()` tracks command usage per month and returns the new count; `getUsage()`/`getTotalUsage()` read counters; `clearOldEntries()` prunes stale rows.
 
 ## MatchPollRepository.kt
-- Poll lifecycle: `addPoll()`, `markPollPosted()`, `markPollClosed()`, and `getPendingPolls()` store poll metadata; `existsPollForDate()` prevents duplicates; `getPollByFixtureId()` retrieves poll details.
+- Poll lifecycle: `addPoll()`, `markPollPosted()`, `markPollClosed()`, `getPendingPolls()`, and `getOpenPostedPolls()` store and reconcile poll metadata; `existsPollForDate()` prevents duplicates; `getPollByFixtureId()` retrieves poll details.
 
 ## UserStatsRepository.kt
 - User counters: `addUserActivity()` logs interactions with names; `getUserCount()` and `getActiveUserCountLast24Hours()` provide metrics for Prometheus and messaging.

--- a/src/main/kotlin/repository/MatchPollRepository.kt
+++ b/src/main/kotlin/repository/MatchPollRepository.kt
@@ -112,4 +112,28 @@ class MatchPollRepository {
         conn.close()
         return polls
     }
+
+    fun getOpenPostedPolls(): List<MatchPoll> {
+        val conn = getConnection()
+        val stmt = conn.prepareStatement(
+            "SELECT fixture_id, teams, poll_message_id, poll_id, poll_date, closed " +
+                    "FROM match_polls WHERE poll_message_id IS NOT NULL AND closed = 0"
+        )
+        val rs = stmt.executeQuery()
+        val polls = mutableListOf<MatchPoll>()
+        while (rs.next()) {
+            polls += MatchPoll(
+                rs.getString("fixture_id"),
+                rs.getString("teams"),
+                rs.getString("poll_message_id"),
+                rs.getString("poll_id"),
+                rs.getString("poll_date"),
+                rs.getInt("closed") == 1
+            )
+        }
+        rs.close()
+        stmt.close()
+        conn.close()
+        return polls
+    }
 }

--- a/src/main/kotlin/repository/MatchRepository.kt
+++ b/src/main/kotlin/repository/MatchRepository.kt
@@ -17,7 +17,6 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.greaterEq
 import org.jetbrains.exposed.sql.or
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.slf4j.LoggerFactory
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -95,7 +94,6 @@ object LeaguePredictability : Table() {
 class MatchRepository {
     private val logger = LoggerFactory.getLogger(MatchRepository::class.java)
     private val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-    private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
     private val listOfLeagues = mutableSetOf<String>()
 
     private fun loadLeagues() {
@@ -424,9 +422,10 @@ class MatchRepository {
         return matchesToUpdate
     }
 
-    fun getMatchesFromLastDaysWithoutResult(days: Int): List<MatchInfo> {
+    fun getMatchesAroundNowWithoutResult(daysBefore: Int, daysAfter: Int): List<MatchInfo> {
         val now = LocalDateTime.now(ZoneOffset.UTC)
-        val startDate = now.minusDays(days.toLong())
+        val startDate = now.minusDays(daysBefore.toLong())
+        val endDate = now.plusDays(daysAfter.toLong())
         val matchesToUpdate = mutableListOf<MatchInfo>()
         transaction {
             listOfLeagues.forEach { leagueName ->
@@ -434,7 +433,9 @@ class MatchRepository {
                 addMissingColumnsForLeague(leagueName)
                 leagueTable.selectAll().mapNotNullTo(matchesToUpdate) { row ->
                     val matchDateTime = LocalDateTime.parse(row[leagueTable.datetime], dateTimeFormatter)
-                    val isWithinRange = matchDateTime.isAfter(startDate) && matchDateTime.isBefore(now) && row[leagueTable.actualOutcome] == null
+                    val isWithinRange = matchDateTime.isAfter(startDate) &&
+                            matchDateTime.isBefore(endDate) &&
+                            row[leagueTable.actualOutcome] == null
                     if (isWithinRange) mapRowToMatchInfo(row, leagueTable) else null
                 }
             }
@@ -455,21 +456,6 @@ class MatchRepository {
             }
         }
         return matchInfo
-    }
-
-    fun getMatchesOlderThanOneDayWithoutResult(date: LocalDate): List<MatchInfo> {
-        val matches = mutableListOf<MatchInfo>()
-        transaction {
-            listOfLeagues.forEach { leagueName ->
-                val leagueTable = LeagueTableFactory.getTableForLeague(leagueName)
-                addMissingColumnsForLeague(leagueName)
-                leagueTable.select {
-                    (leagueTable.datetime lessEq date.format(dateFormatter)) and
-                            leagueTable.actualOutcome.isNull()
-                }.mapNotNullTo(matches) { mapRowToMatchInfo(it, leagueTable) }
-            }
-        }
-        return matches
     }
 
     fun getLastMatches(days: Int): List<MatchInfo> {

--- a/src/main/kotlin/service/HttpAPIFootballService.kt
+++ b/src/main/kotlin/service/HttpAPIFootballService.kt
@@ -26,6 +26,9 @@ import java.time.OffsetDateTime
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
+internal fun isUnavailableFixtureStatus(statusShort: String?): Boolean =
+    statusShort == "PST" || statusShort == "CANC"
+
 class HttpAPIFootballService(private val footballBot: FootballBot) {
     private val logger = LoggerFactory.getLogger(HttpAPIFootballService::class.java)
     private val apiKey: String = Config.getProperty("api-football.token") ?: throw IllegalStateException("API Key not found")
@@ -304,9 +307,6 @@ class HttpAPIFootballService(private val footballBot: FootballBot) {
     }
 
     suspend fun updatePastMatches() {
-        val currentDate = LocalDate.now()
-        val oneDayAgo = currentDate.minusDays(1)
-
         val messagesToUpdate = mutableMapOf<Pair<String?, String?>, MatchInfo>()
         val messagesMap = mutableSetOf<Pair<String, String>>()
         val strategyMap = mutableSetOf<Pair<String, String>>()
@@ -327,37 +327,35 @@ class HttpAPIFootballService(private val footballBot: FootballBot) {
             }
         }
 
-        val matches = DatabaseService.matches.getMatchesFromLastDaysWithoutResult(2)
+        val matches = DatabaseService.matches.getMatchesAroundNowWithoutResult(daysBefore = 2, daysAfter = 2)
         for (match in matches) {
             val liveResult = getLiveMatchInfoWithStatus(match.fixtureId)
             if (liveResult != null && liveResult.matchInfo.actualOutcome != null) {
                 DatabaseService.matches.updateMatchResult(liveResult.matchInfo)
+                footballBot.finalizeMatchPollIfNeeded(liveResult.matchInfo)
                 trackUpdatedMatch(liveResult.matchInfo)
                 delay(1000)
                 continue
             }
 
-            if (liveResult?.statusShort == "PST") {
-                DatabaseService.matches.deleteMatchByFixtureId(match.fixtureId, match.matchType)
-                trackRemovedMatch(match)
-            } else if (liveResult?.statusShort == "CANC") {
+            if (isUnavailableFixtureStatus(liveResult?.statusShort)) {
                 DatabaseService.matches.deleteMatchByFixtureId(match.fixtureId, match.matchType)
                 trackRemovedMatch(match)
             }
             delay(1000)
         }
 
+        DatabaseService.polls.getOpenPostedPolls().forEach { poll ->
+            val match = DatabaseService.matches.getMatchInfoByFixtureId(poll.fixtureId)
+            if (match?.actualOutcome != null) {
+                footballBot.finalizeMatchPollIfNeeded(match)
+                delay(1000)
+            }
+        }
+
         for ((_, info) in messagesToUpdate) {
             footballBot.updateMatchMessages(info)
             delay(10000)
-        }
-
-        // Delete matches older than one day with no actual result
-        val matchesToDelete = DatabaseService.matches.getMatchesOlderThanOneDayWithoutResult(oneDayAgo)
-
-        matchesToDelete.forEach { matchInfo ->
-            DatabaseService.matches.deleteMatchByFixtureId(matchInfo.fixtureId, matchInfo.matchType)
-            trackRemovedMatch(matchInfo)
         }
 
         for ((league, msgId) in messagesMap) {

--- a/src/test/kotlin/service/HttpAPIFootballServiceTest.kt
+++ b/src/test/kotlin/service/HttpAPIFootballServiceTest.kt
@@ -1,0 +1,20 @@
+package service
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HttpAPIFootballServiceTest {
+    @Test
+    fun `only postponed and cancelled fixtures are unavailable`() {
+        assertTrue(isUnavailableFixtureStatus("PST"))
+        assertTrue(isUnavailableFixtureStatus("CANC"))
+
+        listOf(null, "NS", "1H", "HT", "2H", "FT", "AET", "PEN").forEach { status ->
+            assertFalse(
+                isUnavailableFixtureStatus(status),
+                "Fixture with status $status must remain stored"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What changed
- defer destructive `PST`/`CANC` handling from live updates to the past-match reconciliation pass
- remove unconditional age-based deletion of unresolved matches
- reconcile unresolved fixtures across a bounded past/future window
- finalize polls when results arrive late and recover already-published open polls
- add regression coverage for removable fixture statuses

## Root cause
A live status caused the World Cup fixture row to be deleted. A later fetch inserted the same fixture again without its Telegram message ID, so subsequent message reconstruction omitted the match and the poll stayed open even though the result had been saved.

## Impact
Transient fixture statuses no longer destroy Telegram message linkage. Confirmed cancelled or postponed fixtures are still removed during reconciliation, while completed fixtures retain their prediction and publish poll results.

## Validation
- `./gradlew test`
- deployed commit `cd044ef9320a` to HDC test/prod
- both containers healthy
- metrics endpoints returned HTTP 200